### PR TITLE
Fix token initialization in list constructor

### DIFF
--- a/lib/src/list.ts
+++ b/lib/src/list.ts
@@ -60,7 +60,7 @@ export default class LIST {
 
             const token = this.getToken();
             if (token) {
-                this.setToken(token);
+                this.authClient.setToken(token);
             }
 
             unwinder.reset();


### PR DESCRIPTION
Previous commit introduced a regression by trying to connect the
websocket prematurely, broke the UI.

Use the private token method instead of the public one fix this.