### PR TITLE
Introduce capturing pcap type

### DIFF
--- a/lib/src/api/pcap.ts
+++ b/lib/src/api/pcap.ts
@@ -223,6 +223,12 @@ export interface IStreamAnalysis {
     details?: any;
 }
 
+export interface IPcapFileCapturing {
+    id: string;
+    file_name: string;
+    progress: number;
+}
+
 export interface IPcapFileReceived {
     id: string;
     file_name: string;

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -3,7 +3,7 @@ import * as api from './api';
 export type IPcapInfo = api.pcap.IPcapInfo;
 export type IStreamInfo = api.pcap.IStreamInfo;
 export type IFrameInfo = api.stream.IFrameInfo;
-
+export type IPcapFileCapturing = api.pcap.IPcapFileCapturing;
 export type IPcapFileReceived = api.pcap.IPcapFileReceived;
 
 export type IAnalysisProfiles = api.pcap.IAnalysisProfiles;


### PR DESCRIPTION
This allows to properly monitor the capture progress through a websocket
for example.