### PR TITLE
Bumped axios from 0.21.1 to 1.15.2

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -37,6 +37,6 @@
         "@bisect/bisect-core-ts": "^0.1.0",
         "jwt-decode": "^3.0.0",
         "socket.io": "^2.4.0",
-        "axios": "^0.21.1"
+        "axios": "^1.15.2"
     }
 }


### PR DESCRIPTION
Bumped axios version to 1.15.2 due to the presence of several high severity vulnerabilities.